### PR TITLE
Posts under 'Writing' on index.md return 404 error

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ Currently working as an independent consultant. I use my expertise in recommenda
 
 ## Writing
 
-- [Advice for young people](./posts/advice.md)
-- [What I learned from trying](./posts/learning.md)
+- [Advice for young people](./writing/posts/advice.md)
+- [What I learned from trying](./writing/posts/learning.md)
 
 ## Systems
 


### PR DESCRIPTION
Issue:
- The posts "Advice for young people" and "What I learned from trying" (`./posts/advice.md` and `./posts/learning.md`) cannot be found at [https://jxnl.github.io/blog/] because clicking on them results in a 404 error
- This is caused by the posts being in a different location
- Edit: issue appears under `docs/index.md` and not `docs/writing/index.md`

Solution:
- Update links in index.md for the posts to `./writing/posts/advice.md` and `./writing/posts/learning.md` to correctly reference their locations
- I tested this solution using mkdocs locally and can confirm that the links will work correctly after making this change