### PR TITLE
fix SOP link for Predictions for the Future of RAG writing post

### DIFF
--- a/docs/writing/posts/rag_plusplus.md
+++ b/docs/writing/posts/rag_plusplus.md
@@ -36,7 +36,7 @@ Furthermore, how reports are written is incredibly important. Scaling decision-m
 
 One of the reasons I attend workshops, get coaching, or read business books is because the outcome I am looking for is an SOP. For instance, I learned a way to write sales engagement letters that convert better. Now, all of my meetings fit this format and help make me far more money than the $40 dollar book I learned the template from cost. People are taught to give feedback and answer questions in specific ways. You get better outcomes when this output is structured correctly in something like a report or a template. Being able to pay for the right report template can be incredibly valuable because it ensures you're getting the outcome you actually need.
 
-![](https://media.geeksforgeeks.org/wp-content/uploads/202404
+![SOP](https://media.geeksforgeeks.org/wp-content/uploads/20240419121413/Aim-of-SOP-(Standard-Operating-Procedure)-copy.webp)
 
 I don't care so much about being able to read a chat transcript of a meeting I had. I care if I can turn that transcript into a format and report that I know will drive my desired business outcomes rather than just save me time. I want the AI to create a memo with clear deliverables for me or summarize the chat transcript to tell me, "This is the objective, this is how we make the decision, and here are the follow-ups."
 


### PR DESCRIPTION
####  Summary 
- Fixed the markdown link for SOP image

#### Description
Just read your writing about future for RAG https://jxnl.co/writing/2024/06/05/predictions-for-the-future-of-rag/, the markdown image link seems to be broken. I like the content, totally agree with the report based output with RAG, report output with google slides or emotion.dev would be awesome too, you know add some ingested/generated images/vids everywhere. Anyway, felt incomplete though after reading with the broken image link. Can't sleep so I tried to extract images from the wp-content path with this hint `"https://media.geeksforgeeks.org/wp-content/uploads/202404"` with python script, didn't work though. I ended up re-reading the part of SOP and searched in google with keyword `"SOP geeksforgeeks 2024"` and there, ended up getting the image that is i think the most relevant one (thinking like `R` in `RAG` with `similarity threshold of ~0.9`)  based from the hint url path. With that I think I can sleep now by creating this PR. (just delete this trash PR if this doesn't help, though it helped me feel satisfied)


#### Screenshot/image
![SOP](https://media.geeksforgeeks.org/wp-content/uploads/20240419121413/Aim-of-SOP-(Standard-Operating-Procedure)-copy.webp)