### PR TITLE
fix broken link

### DIFF
--- a/docs/writing/index.md
+++ b/docs/writing/index.md
@@ -19,7 +19,7 @@ For RAG or LLM related posts, You can check out the categories labels in the sid
 - [How to build a terrible RAG system](./posts/rag-inverted.md)
 - [Low hanging fruit for RAG](./posts/rag-low-hanging-fruit.md)
 - [RAG System Inference Flywheel](./posts/rag-flywheel.md)
-- [Trade offs in Tool Use](./posts/trade-offs-tool-selection.md)
+- [Trade offs in Tool Use](./posts/trade-off-tool-selection.md)
 - [Understanding Search Quality Metrics](./posts/rag-lgtmk.md)
 
 ## Technical Coaching


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a855aba1bd35abca40e86d6a2dcf50d6de9b4a93  | 
|--------|--------|

### Summary:
Fixes a broken link in `docs/writing/index.md` by correcting the file path for "Trade offs in Tool Use".

**Key points**:
- Fixes a broken link in `docs/writing/index.md`.
- Changes link from `./posts/trade-offs-tool-selection.md` to `./posts/trade-off-tool-selection.md`.
- Ensures the link points to the correct file for "Trade offs in Tool Use".


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->