### PR TITLE
Remove polyfill.io link due to supply chain attack vulnerability

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,6 @@ extra_css:
 extra_javascript:
   - javascripts/mathjax.js
   - javascripts/analytics.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 copyright: Copyright &copy; 2023 Jason Liu


### PR DESCRIPTION
This commit replaces the reference to polyfill.io from the codebase and replaces it with one from cloudflare.com in response to the recent security incident involving malicious code injection.

See https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack for more details.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace polyfill.io link with cloudflare.com in `mkdocs.yml` to address supply chain attack vulnerability.
> 
>   - **Security**:
>     - Replaces `https://polyfill.io/v3/polyfill.min.js?features=es6` with `https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6` in `mkdocs.yml` to mitigate supply chain attack vulnerability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fblog&utm_source=github&utm_medium=referral)<sup> for 6fbebd1374dcdebe341c0f6915fb9821d60be3e8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->