### PR TITLE
Update experts-and-vendors.md

### DIFF
--- a/docs/experts-and-vendors.md
+++ b/docs/experts-and-vendors.md
@@ -27,6 +27,9 @@ Over the years, I've built a network of AI and ML specialists, vendors, and indu
 ### [John Berryman](https://arcturus-labs.com/)
 * Author of ["Relevant Search"](https://www.amazon.com/Relevant-Search-applications-Solr-Elasticsearch/dp/161729277X) and ["Prompt Engineering for LLMs"](https://oreillymedia.pxf.io/c/5303529/1975458/15173). Former GitHub Code Search and Copilot contributor.
 
+### [Zhou Yu](https://www.linkedin.com/in/zhouyustanford//)
+* Data science & ML consultant. Diversified & hands-on experience across industries. Work with early stage companies and founders to build 0 to 1 data science capabilities and ML models. Former head of data science. Ex Google, Stitch Fix and Signalfire.
+
 ## Trusted Vendors
 
 ### Braintrust: [Ankur Goyal](https://www.linkedin.com/in/ankrgyl)


### PR DESCRIPTION
Add Zhou Yu on to experts & vendors page
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Zhou Yu as a data science & ML consultant to the experts list in `experts-and-vendors.md`.
> 
>   - **Experts**:
>     - Added Zhou Yu to the experts list in `experts-and-vendors.md`.
>     - Zhou Yu is a data science & ML consultant with experience across industries, working with early-stage companies to build data science capabilities. Former head of data science at Google, Stitch Fix, and Signalfire.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fblog&utm_source=github&utm_medium=referral)<sup> for 3904eea01a851032f8b40d4088df899c4cd93a76. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->