### PR TITLE
Fix spelling / link for lilypad

### DIFF
--- a/docs/writing/posts/rag-anti-patterns-skylar.md
+++ b/docs/writing/posts/rag-anti-patterns-skylar.md
@@ -257,7 +257,7 @@ This approach is particularly important for sensitive domains like healthcare wh
 
 ## What tools are recommended for RAG evaluation?
 
-While tool preferences vary by situation, Lily Pad (from Microscope) is highlighted as particularly useful for teams without AI engineering backgrounds because it enforces best practices around versioning. However, the best approach is often to meet teams where they are and use their existing tools rather than introducing new ones that require vendor approval.
+While tool preferences vary by situation, [Lilypad from Mirascope](https://mirascope.com/docs/lilypad) is highlighted as particularly useful for teams without AI engineering backgrounds because it enforces best practices around versioning. However, the best approach is often to meet teams where they are and use their existing tools rather than introducing new ones that require vendor approval.
 
 ## How important is metadata tagging in RAG systems?
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix spelling and update link for 'Lilypad from Mirascope' in `rag-anti-patterns-skylar.md`.
> 
>   - **Documentation**:
>     - Fix spelling of 'Lilypad' and update link to '[Lilypad from Mirascope](https://mirascope.com/docs/lilypad)' in `rag-anti-patterns-skylar.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fblog&utm_source=github&utm_medium=referral)<sup> for c20c58661f567750ace5897f40b440fa21b83c70. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->