### PR TITLE
Add newsletter CTA to missing RAG posts

### DIFF
--- a/docs/writing/posts/rag-cohort-3-speakers-improving-rag.md
+++ b/docs/writing/posts/rag-cohort-3-speakers-improving-rag.md
@@ -161,3 +161,10 @@ This series is part of my work with [ImprovingRAG.com](https://improvingrag.com/
 Registration is required to receive the Zoom link for these free sessions.
 
 **You can register for individual sessions using the links above.**
+
+## Want to learn more?
+
+I also wrote a 6 week email course on RAG, where I cover everything in my consulting work. It's free and you can:
+
+[Check out the free email course here](https://dub.link/6wk-rag-email){ .md-button .md-button--primary }
+

--- a/docs/writing/posts/rag-course-breakdown.md
+++ b/docs/writing/posts/rag-course-breakdown.md
@@ -293,3 +293,10 @@ People see RAG as “LLM plus chunk text.” That’s the superficial part. The 
 I hope this has clarified the methodical, data-driven path to building a world-class RAG system. Stay sharp—**absence bias** and **intervention bias** are always around the corner. Measure everything, refine your pipeline step by step, and you’ll watch your system’s performance rise.
 
 If you enjoyed this post, you can also check out [improvingrag.com](https://improvingrag.com) a free guide that tries to capture much of what we teach in my [maven course](https://maven.com/applied-llms/rag-playbook).
+
+## Want to learn more?
+
+I also wrote a 6 week email course on RAG, where I cover everything in my consulting work. It's free and you can:
+
+[Check out the free email course here](https://dub.link/6wk-rag-email){ .md-button .md-button--primary }
+

--- a/docs/writing/posts/rag-enterprise-process.md
+++ b/docs/writing/posts/rag-enterprise-process.md
@@ -180,3 +180,10 @@ Last night, if you do know what the economic value is, just build the automation
 ---
 
 _Want to dive deeper into implementation details? I'm working on a guide covering MCP patterns, evaluation frameworks, and case studies from the teams who've reached out through improvingrag.com. [Subscribe to improvingrag.com](https://improvingrag.com) for early access and updates._
+
+## Want to learn more?
+
+I also wrote a 6 week email course on RAG, where I cover everything in my consulting work. It's free and you can:
+
+[Check out the free email course here](https://dub.link/6wk-rag-email){ .md-button .md-button--primary }
+

--- a/docs/writing/posts/rag-only-6-evals.md
+++ b/docs/writing/posts/rag-only-6-evals.md
@@ -194,3 +194,10 @@ Because in RAG evaluation, as in RAG implementation, the systematic approach win
 ---
 
 _What's your experience with RAG evaluation? Do you find yourself focusing on particular metrics more than others? Drop a comment below—I'd love to hear which of these 6 relationships causes you the most headaches._
+
+## Want to learn more?
+
+I also wrote a 6 week email course on RAG, where I cover everything in my consulting work. It's free and you can:
+
+[Check out the free email course here](https://dub.link/6wk-rag-email){ .md-button .md-button--primary }
+

--- a/docs/writing/posts/rag-what-is-rag.md
+++ b/docs/writing/posts/rag-what-is-rag.md
@@ -94,3 +94,10 @@ For a deeper understanding of RAG systems:
 ## Conclusion
 
 RAG represents a powerful approach to combining the strengths of LLMs and external knowledge sources. By carefully designing and implementing the components of a RAG system, you can build applications that deliver more accurate, relevant, and useful information to users. The continuous improvement cycle, driven by data analysis, feedback, and experimentation, ensures that RAG systems evolve and become more sophisticated over time. As the field of RAG continues to advance, we can expect to see even more innovative applications that transform the way we interact with information.
+
+## Want to learn more?
+
+I also wrote a 6 week email course on RAG, where I cover everything in my consulting work. It's free and you can:
+
+[Check out the free email course here](https://dub.link/6wk-rag-email){ .md-button .md-button--primary }
+

--- a/docs/writing/posts/systematically-improving-rag-raindrop.md
+++ b/docs/writing/posts/systematically-improving-rag-raindrop.md
@@ -194,3 +194,10 @@ When building AI systems, you want your improvements to be engineered, repeatabl
 Monitor your system before and after making changes to see if the frequency of related issues decreases. Look for positive user feedback that specifically mentions the improved experience. The most reliable validation comes from seeing a measurable reduction in the issues you were targeting, combined with positive user sentiment about the specific improvements you made.
 
 If you want to see the whole video checkout our [lesson](https://maven.com/p/d792aa/online-evals-and-production-monitoring?utm_medium=ll_share_link&utm_source=instructor)
+
+## Want to learn more?
+
+I also wrote a 6 week email course on RAG, where I cover everything in my consulting work. It's free and you can:
+
+[Check out the free email course here](https://dub.link/6wk-rag-email){ .md-button .md-button--primary }
+


### PR DESCRIPTION
## Summary
- add call-to-action for the RAG email course at the end of several RAG posts

## Testing
- `./check_more_tags.sh`
- `python generate_sitemap.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68683dc646688326a01e2e211cba578d