### PR TITLE
fix: ML to SWE for deterministic example

### DIFF
--- a/docs/writing/posts/mvp.md
+++ b/docs/writing/posts/mvp.md
@@ -42,7 +42,7 @@ An analogy I often use to help understand this concept is as follows: You need s
 
 ## Consider the 80/20 rule
 
-When talking about something being  80% done or 80% ready, it is usually in a machine-learning sense. In this context, each component is deterministic, which means 80% translates to  8 out of 10 features being complete. Once the remaining 2 features are ready, we can ship the product. However, If we want to follow the 80/20 rule, we might be able to ship the product with 80% of the features and then add the remaining 20% later, like a car without a radio or air conditioning. However, The meaning of 80% can vary significantly, and this definition may not apply to an AI-powered application.
+When talking about something being  80% done or 80% ready, it is usually in a software-engineering sense. In this context, each component is deterministic, which means 80% translates to  8 out of 10 features being complete. Once the remaining 2 features are ready, we can ship the product. However, If we want to follow the 80/20 rule, we might be able to ship the product with 80% of the features and then add the remaining 20% later, like a car without a radio or air conditioning. However, The meaning of 80% can vary significantly, and this definition may not apply to an AI-powered application.
 
 ### The issue with Summary Statistics
 


### PR DESCRIPTION
Caught this on a re-read.

Thanks for the goldmine of content. Closed a client this week which was greatly helped by it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects terminology from 'machine-learning' to 'software-engineering' in `mvp.md` for clarity in the 80/20 rule context.
> 
>   - **Text Correction**:
>     - In `mvp.md`, change 'machine-learning sense' to 'software-engineering sense' in the 80/20 rule discussion for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fblog&utm_source=github&utm_medium=referral)<sup> for 695a1410baaeb626a5ade2564c48d4bb155e88ec. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->