### PR TITLE
fix unordered list formatting for mkdocs

### DIFF
--- a/docs/writing/posts/context-engineering-agent-prototyping.md
+++ b/docs/writing/posts/context-engineering-agent-prototyping.md
@@ -27,6 +27,7 @@ Most teams waste months building agent frameworks before they know if their idea
 ## The Core Problem
 
 When teams want to test an agent idea, they typically start by building infrastructure:
+
 - Message management systems
 - Tool call parsing logic  
 - Retry mechanisms
@@ -46,6 +47,7 @@ Claude Code has a project runner mode (`claude -p`) that turns any directory int
 While this article shows Claude Code, the approach is agent-agnostic. If a coding system can be driven from a CLI and read a simple instruction file (for example, `CLAUDE.md` or `agents.md`), you can use it with this harness.
 
 Examples that fit (or can with a thin adapter):
+
 - Cursor’s coding agent
 - Devin
 - AMP Code
@@ -53,6 +55,7 @@ Examples that fit (or can with a thin adapter):
 - Windsurf Agent
 
 This also unlocks cross-agent evals:
+
 - Keep the same `commands/` and `subagents/` folders and success criteria
 - Add a small wrapper per agent that maps a standard command (for example, `run-agent <scenario-dir>`) to its CLI flags or subcommands
 - Run the same scenarios across agents and compare pass rate, time, and cost


### PR DESCRIPTION
i think mkdocs needs a newline after : in unordered lists. realised this while I was writing a few guides for ragas. add a cursor rule or claude.md to fix it long term. 

before this fix:

<img width="732" height="108" alt="Screenshot 2025-09-05 at 11 49 51 AM" src="https://github.com/user-attachments/assets/0608e735-0c1c-4fc0-978d-36386a3a3c64" />

<img width="712" height="90" alt="Screenshot 2025-09-05 at 11 52 24 AM" src="https://github.com/user-attachments/assets/00da292e-9373-4e20-8614-3ffe4b34d93c" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes unordered list formatting in `context-engineering-agent-prototyping.md` for mkdocs by adding newlines after colons.
> 
>   - **Formatting Fix**:
>     - Adds newline after colons in unordered lists in `context-engineering-agent-prototyping.md` to fix rendering issues in mkdocs.
>   - **Misc**:
>     - Removes unnecessary newline at end of file in `context-engineering-agent-prototyping.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fblog&utm_source=github&utm_medium=referral)<sup> for 30f9733449708252b22c1fe97b0f2897622798fe. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->