### PR TITLE
Context Engineering: question-style headings, index Glossary & usage

### DIFF
--- a/docs/writing/posts/context-engineering-agent-frameworks.md
+++ b/docs/writing/posts/context-engineering-agent-frameworks.md
@@ -14,11 +14,11 @@ tags:
   - Series
 ---
 
-# Context Engineering: Agent Frameworks and Form Factors
+# How Should We Choose Agent Frameworks and Form Factors?
 
 *This is part of the [Context Engineering Series](./context-engineering-index.md). I'm focusing on agent frameworks because understanding form factors and complexity levels is essential before building any agentic system.*
 
-## Part I — What I actually talk about when companies say they want to build agents
+## What Do We Actually Mean When We Say We Want to Build Agents?
 
 *Field note from a conversation with [Vignesh Mohankumar](https://nila.is/), a successful consultant who helps companies navigate AI implementation decisions. [Vignesh](https://nila.is/) and I are both AI consultants helping companies build AI systems—he focuses on implementations and workflows, while I help with overall strategy and execution.*
 
@@ -49,7 +49,7 @@ Everything else is preference.
 
 A practical question that comes up frequently: should you build custom tools or use MCP servers? The economics are more important than the technical architecture.
 
-## The MCP Decision Matrix
+## When Should We Choose MCP?
 
 MCP servers make sense when you need the same tools across multiple applications. If your team uses Claude Desktop, ChatGPT, and other AI platforms that all need Google Drive integration, an MCP server lets you build once and reuse everywhere.
 
@@ -72,7 +72,7 @@ If you're answering "multiple platforms," "existing infrastructure," "complex to
 
 ---
 
-## Part II — The autonomy spectrum (what we can safely automate, and how)
+## How Does the Autonomy Spectrum Guide What We Automate?
 
 When leadership hears "agent," they imagine fully autonomous systems. That's not what works in practice. Successful systems follow a spectrum of increasing autonomy. Here's the progression I recommend:
 
@@ -106,7 +106,7 @@ This is the classic "agent": a loop where the AI suggests an action, you execute
 
 This progression gives you a clear upgrade path. You don't need to start with the most complex option. Begin with deterministic code, add AI functions where you need flexibility, use chains when tasks have multiple steps, upgrade to graphs when workflows branch, and save the tool-calling loop for cases that truly need improvisation. This builds reliability step by step.
 
-## The Key Insight: Every Level is a Tool for Higher Levels
+## Why Is Every Level a Tool for Higher Levels?
 
 Here's what makes this spectrum powerful: **any system at any level can become a tool for systems at higher levels**. A deterministic script becomes a tool for an AI function. An AI function becomes a tool for a prompt chain. A complete prompt chain becomes a tool for a graph state machine. Even an entire tool-calling agent can be a single tool in a larger orchestration system.
 
@@ -122,7 +122,7 @@ Think of it this way:
 
 This creates an architecture where simple, reliable components compose into more complex systems. The customer support agent that routes to password reset isn't calling a single API—it's calling a complete Level 2 chain that handles authentication, validation, and email generation. From the agent's perspective, it's just another tool.
 
-### Why This Matters for Architecture
+### Why Does This Matter for Architecture?
 
 **Testability**: Each level can be tested independently. Your Level 1 AI function works reliably before it becomes a tool in your Level 2 chain.
 
@@ -138,7 +138,7 @@ This is how you build agent systems that actually work in production: not as mon
 
 ---
 
-## From Concept to Working System
+## How Do We Go from Concept to Working System?
 
 A critical question comes up in every agent consulting engagement: *How do you test whether an agent idea actually works without building all the infrastructure first?*
 
@@ -152,7 +152,7 @@ The methodology also integrates with all the other context engineering patterns:
 
 ---
 
-## A note to leadership
+## What Should Leadership Ask For?
 
 Ask your team for specific results, not just "agents." Have them pick one of the three approaches—**chatbot**, **workflow**, or **report generator**—and define success. Ask where they'll start on the complexity spectrum and when they'd add more AI.
 

--- a/docs/writing/posts/context-engineering-agent-prototyping.md
+++ b/docs/writing/posts/context-engineering-agent-prototyping.md
@@ -14,7 +14,7 @@ tags:
   - Series
 ---
 
-# Context Engineering: Rapid Agent Prototyping
+# How Do We Prototype Agents Rapidly?
 
 *This is part of the [Context Engineering Series](./context-engineering-index.md). I'm focusing on rapid prototyping because testing agent viability quickly is essential for good context engineering decisions.*
 
@@ -24,7 +24,7 @@ Most teams waste months building agent frameworks before they know if their idea
 
 <!-- more -->
 
-## The Core Problem
+## What Problem Does Rapid Prototyping Solve?
 
 When teams want to test an agent idea, they typically start by building infrastructure:
 - Message management systems
@@ -35,13 +35,13 @@ When teams want to test an agent idea, they typically start by building infrastr
 
 By the time they get to testing the actual agent behavior, they've invested weeks in plumbing. Often they discover the fundamental idea doesn't work, but only after significant engineering investment.
 
-## The Claude Code SDK Solution
+## How Does the Claude Code SDK Help?
 
 Claude Code has a project runner mode (`claude -p`) that turns any directory into an agent execution environment. It reads a `CLAUDE.md` file as system instructions and executes workflows using CLI tools you provide. This creates a perfect testing harness—you write instructions in English, expose tools as simple commands, and let Claude Code handle the execution loop.
 
 **The key insight**: If it works once in this harness, the idea is viable. If it fails consistently, you know what's missing without building any infrastructure.
 
-## Works With Any Coding Agent
+## Which Coding Agents Does This Work With?
 
 While this article shows Claude Code, the approach is agent-agnostic. If a coding system can be driven from a CLI and read a simple instruction file (for example, `CLAUDE.md` or `agents.md`), you can use it with this harness.
 
@@ -59,7 +59,7 @@ This also unlocks cross-agent evals:
 
 As features converge (slash commands, subagents, instruction files), you can swap the runner without changing your prototype. This lets you identify the useful components of systems that actually work well, separate from any single vendor.
 
-## The Anatomy of a Rapid Prototype
+## What Is the Anatomy of a Rapid Prototype?
 
 Here's the exact structure that lets you test any agent idea:
 
@@ -83,7 +83,7 @@ agent-prototype/
         └── check.py
 ```
 
-### The CLAUDE.md File: Your Executable Specification
+### What Goes in CLAUDE.md?
 
 This becomes your system prompt, structured for execution:
 
@@ -117,7 +117,7 @@ Final notes.md must contain:
 - If cleanup unnecessary (already clean), proceed directly to notes-writer
 ```
 
-### Tool Implementations: Simple CLI Wrappers
+### How Should We Implement Tools as CLI Wrappers?
 
 Tools should be deliberately simple—CLI commands that wrap your actual APIs. This connects directly to the [tool response design principles](./context-engineering-tool-response.md) I've written about—the structure of your tool outputs becomes as important as the functionality itself:
 
@@ -139,7 +139,7 @@ fi
 echo "SUCCESS: Transcript downloaded"
 ```
 
-### Test Validation: Make Success Concrete
+### How Do We Validate Success in Tests?
 
 Each test folder represents a real scenario with concrete pass/fail criteria:
 
@@ -172,7 +172,7 @@ for i, section in enumerate(sections[1:], 1):
 print("✅ All structural requirements met")
 ```
 
-## The Execution Protocol
+## How Do We Execute the Prototype?
 
 To test any agent idea:
 
@@ -182,7 +182,7 @@ To test any agent idea:
 
 What you observe is Claude Code reading instructions, selecting tools, handling errors, and producing artifacts. You can watch it navigate edge cases in real-time—like when a video lacks English subtitles, it explores alternatives rather than simply failing.
 
-## Why This Beats Building Infrastructure First
+## Why Is This Better Than Building Infrastructure First?
 
 **Iteration speed**: You edit text files, not debug message loops or tool call parsing.
 
@@ -194,9 +194,9 @@ What you observe is Claude Code reading instructions, selecting tools, handling 
 
 **Economic transparency**: Token costs, latency, and failure rates visible in hours, not sprints.
 
-## Advanced Patterns for Production Readiness
+## How Do We Prepare for Production?
 
-### Teaching Through Tool Errors
+### How Can Tool Errors Teach Next Actions?
 
 Instead of generic failures, tools should guide next actions:
 
@@ -208,7 +208,7 @@ if [ -z "$user_id" ]; then
 fi
 ```
 
-### Structured Tool Responses
+### How Should We Structure Tool Responses?
 
 Control output format for easier parsing. This is a practical application of the [context engineering principles](./context-engineering-tool-response.md) around faceted tool responses—providing metadata that helps agents make better decisions:
 
@@ -252,7 +252,7 @@ For transcripts >50,000 characters:
 
 **Production migration**: Successful test folders become your production test suite. Tools and instructions transfer directly to any framework you build.
 
-## When This Methodology Doesn't Apply
+## When Doesn't This Methodology Apply?
 
 The boundaries are narrower than you might expect:
 
@@ -267,7 +267,7 @@ The boundaries are narrower than you might expect:
 
 But for the fundamental question—"Is this agent idea possible?"—this provides the fastest path to evidence in almost all cases.
 
-## Implementation Checklist
+## What Checklist Guides Implementation?
 
 Before writing orchestration code:
 
@@ -280,7 +280,7 @@ Before writing orchestration code:
 - [ ] **Achieve at least one passing test** before considering production architecture
 - [ ] **Explore architectural patterns**: Use the prototype to test whether [slash commands or subagents](./context-engineering-slash-commands-subagents.md) work better for your specific use case
 
-## Conclusion
+## What Is the Bottom Line?
 
 Stop building agent infrastructure before you know if the idea works. Use this methodology to get evidence in hours:
 
@@ -293,7 +293,7 @@ If Claude Code can't make it work with perfect tool access and no constraints, y
 
 **The fastest way to prototype an agent isn't to build an agent at all—it's to test whether the idea works before you build anything.**
 
-## Connection to the Broader Context Engineering Framework
+## How Does This Connect to the Context Engineering Framework?
 
 This prototyping methodology integrates with all the other context engineering patterns:
 

--- a/docs/writing/posts/context-engineering-compaction.md
+++ b/docs/writing/posts/context-engineering-compaction.md
@@ -10,7 +10,7 @@ tags:
   - Compaction
 ---
 
-# Two Experiments We Need to Run on AI Agent Compaction
+# What Experiments Should We Run on AI Agent Compaction?
 
 **Two core insights:**
 
@@ -25,7 +25,7 @@ Through my [consulting work](https://jxnl.co/services/), I help companies build 
 
 This builds on the foundational concepts I've explored in [context engineering](./context-engineering-tool-response.md), where the structure of information flow becomes as critical as the information itself.
 
-## Glossary
+## What Do These Compaction Terms Mean?
 
 **Compaction**: Automatic summarization of conversation history when context windows approach limits, preserving essential information while freeing memory space.
 
@@ -37,7 +37,7 @@ This builds on the foundational concepts I've explored in [context engineering](
 
 <!-- more -->
 
-## The Momentum Analogy
+## Why Is Compaction Like Momentum?
 
 Traditional gradient descent with momentum:
 
@@ -111,7 +111,7 @@ Compact emphasizing: correction requests, preference statements,
 workflow interruptions, and satisfaction indicators.
 ```
 
-### Expected Discoveries
+### What Do We Expect to Discover?
 
 I suspect we'd find things like:
 
@@ -126,7 +126,7 @@ Here's why this matters: [Clio](https://www.anthropic.com/research/clio) found t
 
 This type of systematic analysis aligns with the [data flywheel approaches](./data-flywheel.md) that help AI systems improve through user feedback loops—but applied to multi-step reasoning rather than single predictions.
 
-### The Clustering Approach
+### How Would the Clustering Approach Work?
 
 1. **Compact trajectories** using specialized prompts
 2. **Cluster compacted summaries** using embedding similarity
@@ -137,7 +137,7 @@ This is trajectory-level observability. Instead of just knowing "agents do codin
 
 It's similar to the systematic improvement approaches I cover in [RAG system optimization](./rag-flywheel.md), but focused on agent behavior patterns rather than search relevance.
 
-## The Missing Infrastructure
+## What Infrastructure Is Missing?
 
 Context windows keep getting bigger, but we still hit limits on complex tasks. More importantly, we have no systematic understanding of how agents actually learn and fail over long interactions.
 
@@ -145,13 +145,13 @@ This connects to fundamental questions about [how AI engineering teams should ru
 
 Companies building agents could figure out why some trajectories work and others don't. Researchers could connect theory to practice. The field could move beyond single-turn benchmarks toward understanding actual agentic learning.
 
-## Getting Started
+## How Do We Get Started?
 
 The momentum experiment realistically needs a company already running coding agents at scale. The observability experiment could work for anyone with substantial agent usage data.
 
 Both need access to long trajectories and willingness to run controlled experiments.
 
-## Let's Collaborate
+## Who Should Collaborate on This?
 
 If you're working with agents at scale and want to explore these directions, [I'd love to collaborate](https://jxnl.co/services/). These sit at the intersection of ML theory and practical deployment—exactly where the most interesting problems live.
 

--- a/docs/writing/posts/context-engineering-index.md
+++ b/docs/writing/posts/context-engineering-index.md
@@ -10,7 +10,7 @@ tags:
   - Series
 ---
 
-# Context Engineering Series: Building Better Agentic RAG Systems
+# What Is the Context Engineering Series for Agentic RAG Systems?
 
 I've been helping companies build agentic RAG systems and studying coding agents from Cognition, Claude Code, Cursor, and others. These coding agents are probably unlocking a trillion-dollar industry—making them the most economically viable agents to date.
 
@@ -20,11 +20,26 @@ This series shares what I've learned from these teams and conversations with pro
 
 ## What is Context Engineering?
 
-We've moved far beyond prompt engineering. Now we're designing portfolios of tools (directory listing, file editing, web search), slash commands like `/pr-create` that inject prompts vs , specialized sub-agents `@pr-creation-agent`, vs having an `AGENT.md` with systems that work across IDEs, command lines, GitHub, and Slack.
+We've moved far beyond prompt engineering. Now we're designing portfolios of tools (directory listing, file editing, web search), slash commands like `/pr-create` that inject prompts, specialized subagents such as `@pr-creation-agent`, and instruction files like `AGENT.md` that work across IDEs, command lines, GitHub, and Slack.
 
 Context engineering is designing tool responses and interaction patterns that give agents situational awareness to navigate complex information spaces effectively.
 
 To understand what this means practically, let's look at how systems have evolved:
+
+## What Key Terms Should I Know?
+
+- Context Engineering: Designing tool responses and interaction patterns that teach agents how to navigate data landscapes, not just consume chunks.
+- Faceted Search: Returning metadata aggregations (counts, categories) alongside results so agents can refine queries strategically.
+- Agent Peripheral Vision: Structured hints about the broader information space beyond top‑k results.
+- Tool Response as Prompt Engineering: Using structure (XML/JSON), metadata, and inline system instructions in tool outputs to shape future behavior.
+- Context Pollution: Noisy, low-signal outputs (logs, traces) that crowd out useful reasoning context.
+- Context Rot: Reliability degrading as conversations get longer and messier.
+- Subagents: Specialized sidecar agents that do token-heavy, messy reads in isolation and return distilled summaries.
+- Compaction: Summarizing conversation history to preserve essential trajectory while freeing context; treated as “momentum” in this series.
+- Agent Trajectory: The full sequence of tool calls, steps, and messages that accomplish a task.
+- Form Factors: Chatbots (conversational), workflows (side‑effect engines), and research artifacts (reports/tables).
+- MCP (Model Context Protocol): A protocol for reusable tools across clients; best when reuse and client diversity justify the overhead.
+- RAG: Retrieval‑augmented generation; here, evolved from chunks to structured, faceted information landscapes.
 
 **Before:** We precomputed what chunks needed to be put into context, injected them, and then asked the system to reason about the chunks. Search was a one-shot operation—you got your top-k results and that was it.
 
@@ -92,7 +107,7 @@ The fundamental shift is this: **agents don't just consume information, they exp
 
 <!-- more -->
 
-## What This Series Covers
+## What Does This Series Cover?
 
 This series explores practical approaches to context engineering across different domains and use cases. The focus is on implementation strategies, real-world examples, and measurable business outcomes from companies making this transition.
 
@@ -104,7 +119,7 @@ This series explores practical approaches to context engineering across differen
 - Performance optimization for agentic workloads
 - Business metrics and ROI measurement strategies
 
-## Posts in This Series
+## What Posts Are in This Series?
 
 ### 1. [Beyond Chunks: Context Engineering Tool Response](./context-engineering-tool-response.md)
 
@@ -138,7 +153,20 @@ This series explores practical approaches to context engineering across differen
 
 **Start Here:** If you're new to context engineering, begin with the foundational post above, then explore agent frameworks and prototyping approaches.
 
-## Who This Series Is For
+## How Should I Use This Series?
+
+- Quick Start: Audit your tool responses for sources and structure; add Level 2 (source metadata) immediately.
+- Prototype: Use a CLAUDE.md + CLI tools + scenario checks to validate one task end‑to‑end before building orchestration.
+- Isolate Noise: Keep test logs and heavy reads in subagents; return summaries to main thread.
+- Measure: Track clarification rate, expert escalations, 504s, and resolution time before/after changes.
+- Plan Compaction: Choose when and how to compact; test timing and prompts on long trajectories.
+
+- Recommended Paths by Role:
+  - Engineering: Tool Response → Rapid Prototyping → Slash vs Subagents → Compaction → Frameworks
+  - Product/Leads: Frameworks → Rapid Prototyping → Tool Response → Slash vs Subagents
+  - Researchers: Compaction → Tool Response → Slash vs Subagents → Rapid Prototyping
+
+## Who Is This Series For?
 
 - **Engineering teams** building agentic RAG systems
 - **Product leaders** evaluating the ROI of agent implementations  
@@ -147,7 +175,7 @@ This series explores practical approaches to context engineering across differen
 
 Each post includes practical code examples, implementation strategies, and real business metrics from companies that have made this transition.
 
-## Getting Started
+## How Do I Get Started?
 
 Start with the foundational post [Beyond Chunks: Why Context Engineering is the Future of RAG](./context-engineering-tool-response.md) to understand the core thesis and four-level framework. From there, you can either read sequentially or jump to specific topics based on your current implementation needs.
 

--- a/docs/writing/posts/context-engineering-slash-commands-subagents.md
+++ b/docs/writing/posts/context-engineering-slash-commands-subagents.md
@@ -11,7 +11,7 @@ tags:
 series: Context Engineering
 ---
 
-# Slash Commands vs Subagents: How to Keep AI Tools Focused
+# How Do Slash Commands and Subagents Keep AI Tools Focused?
 
 **The main idea:** When AI tools do messy tasks, they can either stay focused or get confused by too much information.
 
@@ -49,7 +49,7 @@ Coding agents like Claude Code are at the forefront of solving this problem. The
 
 <!-- more -->
 
-## The Slash Command Path (Prompts)
+## What Happens on the Slash Command Path?
 
 Take a simple example: you're building a feature, you touch a few files, and now you need to run tests.
 
@@ -229,7 +229,7 @@ This problem happens in more than just coding tools. As I wrote about in [RAG Lo
 **Context pollution:** 91% noise
 **Problem:** Test diagnostics flood your reasoning thread with massive logs
 
-## The Subagent Path
+## What Is the Subagent Path?
 
 Now instead of using a slash command, you create a Test Runner helper.
 
@@ -291,7 +291,7 @@ I've watched a test runner subagent identify failing tests, run git bisect, and 
 
 A friend built a performance optimization subagent. Their main agent was busy implementing a UX feature, while the subagent ran scripts, parsed logs, did data analysis, and reported: "These three functions cause 70% of latency." The core stayed focused on the feature; the sidecar did the heavy lifting.
 
-# How This Actually Works in Claude Code
+# How Does This Work in Claude Code?
 
 I've been diving into how Claude Code implements this stuff, and it's pretty clever.
 
@@ -320,7 +320,7 @@ I've watched this in action. A friend had a performance optimization subagent th
 
 That's exactly the kind of insight you need, without any of the noise.
 
-## Context Engineering Beyond Code
+## How Does Context Engineering Apply Beyond Code?
 
 This pattern applies far beyond coding assistants. The key insight is **read-only research models** that burn tokens exploring messy data while keeping your main reasoning thread clean.
 
@@ -336,7 +336,7 @@ The pattern is universal: **burn tokens in specialized workers, preserve focus i
 
 But recognize these systems are complicated. If you're building a product, you have to decide whether you want to manually orchestrate these workflows and educate users, or build for expert users who understand the complexity.
 
-## What's Next
+## What Comes Next?
 
 This architectural choice will define how agent systems scale. Teams building production agents today are implementing these patterns now, while the tooling ecosystem catches up.
 

--- a/docs/writing/posts/context-engineering-tool-response.md
+++ b/docs/writing/posts/context-engineering-tool-response.md
@@ -8,7 +8,7 @@ tags:
   - Agents
 ---
 
-# Beyond Chunks: Why Context Engineering is the Future of RAG
+# Why Is Context Engineering the Future of RAG?
 
 **The core insight:** In agentic systems, how we structure tool responses is as important as the information they contain.
 
@@ -37,7 +37,7 @@ This is the fundamental problem with chunk-based RAG in agentic systems. Agents 
 
 <!-- more -->
 
-## Four Levels of Context Engineering
+## What Are the Four Levels of Context Engineering?
 
 I'll demonstrate this through four progressively complex levels:
 
@@ -51,7 +51,7 @@ This progression leads to two key predictions:
 1. **Tool results become prompt engineering** - Metadata teaches agents how to use tools in future calls
 2. **Databases become reasoning partners** - Facets surface patterns that agents leverage but humans wouldn't think to ask for
 
-## Search Quality is Your Ceiling
+## Why Is Search Quality Your Ceiling?
 
 !!! warning "Hard Truth"
 Good search is the ceiling on your RAG quality. If recall is poor, no prompt engineering or model upgrade will save you. I've seen teams spend weeks fine-tuning prompts when their real problem was that the relevant information simply wasn't being retrieved. This is why focusing on the right RAG evaluation metrics is crucial.
@@ -61,7 +61,7 @@ Context engineering goes beyond returning chunks. It's about returning actionabl
 !!! tip "Start Here: Audit Your Current Tools"
 Before building new infrastructure, audit what your tools actually return. Most improvements are just better string formatting—wrapping results in XML, adding source metadata, including system instructions. No major architectural changes required.
 
-## The Complexity Tradeoff
+## How Should We Balance Complexity?
 
 Here's the uncomfortable truth: there's no single right answer for how much metadata to include. Every system has different needs, and the more complex you make your tools, the higher the likelihood of hallucinations and tool misuse.
 
@@ -361,15 +361,15 @@ def search(
 
 **The transformation:** Agents gain peripheral vision of the entire data landscape. Facets reveal hidden documents that similarity search missed, enabling strategic exploration beyond the top-k cutoff.
 
-## Two Types of Facet Data Sources
+## What Types of Facet Data Sources Exist?
 
 Facets can come from two primary sources: existing structured systems and AI-extracted metadata from unstructured documents.
 
-### Structured Systems
+### What Are Structured Systems for Facets?
 
 CRMs, ERPs, HR systems, and other business databases already contain rich structured data that can power faceted search. These systems track entities, relationships, and metadata that users often don't realize can be leveraged for search.
 
-#### Hypothetical Study: Linear Ticket Search
+#### How Would This Work for Linear Ticket Search?
 
 ```python
 def search(
@@ -457,11 +457,11 @@ When an agent searches `search("API timeout issues")`, it gets:
 !!! danger "Similarity Bias Alert"
 All 3 returned tickets are "Done" but facets show 5 "Open" tickets exist. Resolved tickets have better documentation and rank higher in similarity search, while active issues get filtered out. Call `search("API timeout", status="Open")` to find them.
 
-### Extracted Facets
+### What Are Extracted Facets?
 
 Companies like Extend and Reducto can perform structured data extraction over documents to create facets that don't naturally exist in the raw text.
 
-#### Hypothetical Study: Contract Analysis
+#### How Would This Work for Contract Analysis?
 
 ```python
 def search(
@@ -543,7 +543,7 @@ When an agent searches `search("liability provisions")`, it gets:
 !!! warning "Critical Documents Missing"
 All 3 returned contracts are signed, but facets reveal 12 unsigned contracts exist in the broader result set. Signed contracts have better-developed liability language (higher similarity scores), while unsigned contracts with liability provisions didn't make the top-k cut. The agent should call `search("liability", signature_status="Unsigned")` to examine those hidden contracts - they need attention before signing.
 
-## The Persistence Advantage: Why Agents Change Everything
+## Why Does Agent Persistence Change Everything?
 
 This is the paradigm shift most teams miss: agentic systems are incredibly persistent. Given enough budget and time, they'll keep searching until they find what they need. This fundamentally changes how we should think about search system design. This persistence enables continuous feedback loops that improve system performance over time.
 
@@ -557,7 +557,7 @@ Consider the contract example: the agent didn't need to find all liability provi
 
 This transforms the database from a passive responder to an active reasoning partner. Facets surface patterns and gaps that agents can leverage but humans would never think to ask for directly.
 
-## The Evolution from Chunks to Context
+## How Do We Evolve from Chunks to Context?
 
 We've traced the evolution from basic chunks to sophisticated context engineering across four levels. Level 1 gives agents raw text but leaves them blind to metadata patterns. Level 2 adds source tracking, enabling strategic document loading and proper citations. Level 3 optimizes multi-modal content formatting so agents can reason about tables, images, and structured data. Level 4 introduces facets that reveal the complete data landscape, transforming search from similarity-based retrieval to exploration.
 
@@ -565,7 +565,7 @@ The progression shows a clear pattern: **each level adds peripheral vision about
 
 The business impacts are measurable: 90% reduction in clarification questions, 75% reduction in expert escalations, 95% reduction in 504 errors, 4x improvement in resolution times. But the deeper transformation is architectural—databases evolve from passive storage to active reasoning partners that surface patterns human users would never think to request.
 
-## What's Next
+## What Comes Next?
 
 This is the first post in a series on context engineering. I started here because it's the most accessible entry point—something every team can experiment with today.
 


### PR DESCRIPTION
This PR standardizes headings across the Context Engineering series to 5W/How questions (preserving numbering for Levels/Steps/Experiments), adds a concise Glossary and a 'How to Use This Series' section to the index, and fixes a wording glitch in the definition.\n\nChanges:\n- Convert non-numbered headings to questions in 6 posts\n- Preserve numbered headings: Levels 1–4, Steps 0–4, Experiments 1–2\n- Add Glossary + role-based usage guidance to index\n- Minor copy fix in 'What is Context Engineering?' section\n\nNo code blocks edited; only Markdown headings and prose.\n\nPlease review sidebar/nav rendering for long H2s; happy to shorten if needed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes headings to question-style, adds a glossary and usage guide to the index, and fixes minor wording in the Context Engineering series.
> 
>   - **Headings**:
>     - Convert non-numbered headings to question-style in 6 posts.
>     - Preserve numbered headings for Levels, Steps, and Experiments.
>   - **Index Enhancements**:
>     - Add a concise Glossary and 'How to Use This Series' section.
>   - **Copy Fixes**:
>     - Minor wording correction in 'What is Context Engineering?' section.
>   - **Misc**:
>     - No code blocks edited; only Markdown headings and prose.
>     - Request to review sidebar/nav rendering for long H2s.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fblog&utm_source=github&utm_medium=referral)<sup> for 3b962d62a73731b75086186d3c4264ebef548094. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->