### PR TITLE
Fix malformed good faith link in advice post

### DIFF
--- a/docs/writing/posts/advice.md
+++ b/docs/writing/posts/advice.md
@@ -26,7 +26,7 @@ After some more editing I realised that I am actually writing this for my younge
 
 !!! warning "Don't read this if you're seeking a nuanced perspective"
 
-    These are simply the lies I tell myself to keep on living my life in [good faith](https://en.wikipedia.org/wiki/Bad_faith_(existentialism\)). I'm not saying this is the right way to do things. I'm just saying this is how I did things. I will do my best to color my advice with my own experiences, but I'm not going to pretend that the suffering and the privilege I've experienced is universal.
+    These are simply the lies I tell myself to keep on living my life in [good faith](<https://en.wikipedia.org/wiki/Bad_faith_(existentialism)>). I'm not saying this is the right way to do things. I'm just saying this is how I did things. I will do my best to color my advice with my own experiences, but I'm not going to pretend that the suffering and the privilege I've experienced is universal.
 
 <!-- more -->
 


### PR DESCRIPTION
## Summary
- fix the malformed Markdown link for `good faith` in the advice post
- use the parser-safe angle-bracket URL form so the Wikipedia target renders correctly

## Verification
- confirmed the Markdown now renders to a proper anchor tag
- confirmed the local MkDocs preview exposes the expected `href`