### PR TITLE
docs: add codex-maxxing draft post

### DIFF
--- a/docs/writing/posts/codex-maxxing.md
+++ b/docs/writing/posts/codex-maxxing.md
@@ -1,0 +1,221 @@
+---
+title: Codex-maxxing
+description: How I use Codex as a place where long-running work can live.
+date: 2026-05-10
+authors:
+  - jxnl
+categories:
+  - Applied AI
+  - Personal
+comments: true
+draft: true
+slug: codex-maxxing
+tags:
+  - Codex
+  - AI
+  - Workflows
+  - Personal Software
+---
+
+# Codex-maxxing
+
+I had already been using coding agents a lot before Codex. Mostly, though, I used them through interfaces built for coding work: making diffs, changing repos, and shipping code.
+
+Around November, I started pushing them into knowledge work too. I made presentations in Slidev, used agents more like note-takers, and kept looking for other artifacts a coding agent could help me produce.
+
+The Codex app is the first thing I have used that makes that broader mode feel native for everyone. It is still excellent for coding, but the more interesting shift for me is that it gives work somewhere to live.
+
+What changed my behavior was learning to give work five things: a durable thread, a place to remember, tools to act, a schedule that brings it back, and a surface I can review.
+
+<!-- more -->
+
+## Compaction made threads durable
+
+The first thing that changed my behavior was compaction.
+
+I now keep a pinned thread for every important workstream I care about:
+
+- my Chief of Staff thread
+- [the Agents SDK](https://openai.com/index/the-next-evolution-of-the-agents-sdk/)
+- [the OpenAI CLI](https://github.com/openai/openai-cli)
+- [Codex for open source](https://openai.com/form/codex-for-oss)
+- one just to monitor Twitter
+
+These are not short chats. They are megathreads that I have been compacting for months. They accumulate history, preferences, and old decisions that I do not want to recreate every time I come back.
+
+!!! tip "Pinned thread shortcuts"
+
+    You can jump directly to pinned threads with `Command-1` through `Command-9`.
+
+There is a tradeoff here. Long-running threads are not free. If you revisit them later, the conversation is probably no longer in cache, so you can incur more cost than you would in a fresh short thread. But for workstreams I care about, continuity is often more valuable than purity.
+
+## Voice input gives the agent the unedited version
+
+One underrated part of this workflow is getting more of my actual thinking into Codex.
+
+The real benefit of voice input is not speed. It is that I give the agent the unedited version of my thinking. Codex has built-in voice input, but I also use Wispr Flow because system-wide dictation changes how much context I can feed into everything else too. If I am planning a piece of work, I might say, "I think there is some guy named Ben in Slack who mentioned this, I do not remember exactly what, just go look." That sentence is too vague and annoying to type, but completely natural to say.
+
+The same thing applies to transcripts. If I want to write a post, I can call someone, record the conversation, or talk to them in person with Granola on my phone, then use the transcript as the starting material. A lot of plans get better when the model has access to the messy version of what I think, not just the polished one.
+
+## Steering lets me keep adding intent
+
+Voice becomes more useful when combined with steering.
+
+Steering lets you inject the next message after a tool call. That sounds small, but it changes how I work. If I am reviewing a website, I can keep talking while I look at it:
+
+- make this smaller
+- this copy is wrong
+- the spacing between these two things feels off
+- once this is done, open a PR
+- wait for the preview deploy
+- send the preview link to the person who needs to review it on Slack
+
+I do not need to wait for each step to finish before deciding the next one. I can keep adding intent while the agent is still working, then walk away with the queue already shaped.
+
+Later, Heartbeats can monitor the PR or the Slack thread after I leave. The unit of work stops being "one prompt, one answer." It becomes a small operating loop.
+
+## Give the agent somewhere to remember
+
+Once threads started lasting longer, they needed shared memory outside any one repo.
+
+Most of my long-running threads start in an Obsidian vault:
+
+```text
+vault/
+├── TODO.md
+├── people/
+├── projects/
+├── agent/
+└── notes/
+```
+
+At the top level, I keep `AGENTS.md` instructions that say things like: as you learn more about people or make progress on projects, update the relevant pages in the vault.
+
+You should think of the vault as a place your agent can live separate from projects. Repositories hold code. The vault holds rolling context around my work: people, decisions, open loops, daily notes, project state, and the bits of understanding that would otherwise get lost between threads.
+
+I also keep the vault as a GitHub repo. That buys me two things:
+
+1. it can work in the cloud
+2. diffs become a review surface for memory
+
+When the agent updates the vault, I can read the diff and see what it thought was important enough to remember. Reviewing those diffs is effectively how I acknowledge that I have seen what the agent learned.
+
+At that point, pinned threads start to feel less like chats and more like different workers with access to the same shared memory.
+
+## Give those threads reach
+
+Once a thread has memory, the next question is what it can act on.
+
+The most useful distinction in my own head is:
+
+- `$browser` is for local web surfaces I want to inspect and annotate
+- `@chrome` is for signed-in browser state and multiple tabs
+- `@computer` is for work that only exists as a GUI
+
+If I am iterating on a local app, I want `$browser`. If I need to work inside a logged-in browser session, I want `@chrome`. If the only way to do the task is to click through a desktop app, I want `@computer`.
+
+On my work machine, Twitter is logged into Safari. If I have `@computer` read Twitter there, I lose Safari while it works. `@chrome` is better when I want the agent to use several authenticated tabs in parallel without taking over the whole app I am using.
+
+Connectors extend that reach into Slack, Gmail, and Calendar, where much of my work already happens.
+
+Skills make repeated workflows reusable. Skill Creator and Skill Installer are a good place to start. Skill Installer lets you add OpenAI-recommended skills directly from the composer. I used it to install the Hatch Pet skill, but the useful pattern is general: once you do something useful once, you can often package it so Codex can do it again without reteaching the workflow.
+
+## Heartbeats make threads come back on their own
+
+Pinned threads are useful, but they still wait for you to say something. Heartbeats are what make them recur.
+
+A Heartbeat is a thread-local automation. You can say, "keep an eye on this every few hours," and the thread can schedule itself. A thread can have multiple schedules, run until some condition is met, and adjust its cadence over time.
+
+### Chief of Staff
+
+I also have a Chief of Staff thread that runs every 30 minutes:
+
+```text
+Every 30 minutes, check Slack and Gmail for unanswered messages that need my attention.
+Help me prioritize what matters most.
+If someone asks me a question, research the answer as deeply as you can and draft a reply for me, but do not send it.
+```
+
+When I come back to Slack, replies are often already sitting in drafts. I still decide what gets sent, but the expensive part of gathering context is done.
+
+### Monitor for feedback
+
+The same pattern works for review loops. A Heartbeat can monitor Google Docs comments, pull request comments, or Slack replies and keep work moving as feedback arrives.
+
+One of my favorite examples came from an animation project. I had posted a video in Slack and asked Codex to check the thread every 15 minutes for feedback, re-render a new version when comments came in, and reply back into the thread tagging the reviewer. The Slack MCP server could not upload files, so the agent used `@computer` to press the Add file button and post the revised render anyway.
+
+The interesting part is not just that it checked Slack every 15 minutes. The loop crossed tool boundaries: Slack for feedback, Remotion for the render, `@computer` for the upload. That is when Heartbeats, connectors, and computer use stop feeling like separate features. Together they become a feedback loop that keeps running without me sitting there.
+
+### Get a refund
+
+Recently I had a package stolen. Amazon told me it would take about 25 minutes to talk to a person, so I created a thread with `@computer` and told it:
+
+```text
+Every 5 minutes, check whether the customer support agent has joined this thread.
+If they have, do your best to get me a refund.
+Once they reply, switch to checking every minute so you can respond faster.
+```
+
+By the time I got out of the shower, the refund was done.
+
+Many of my Heartbeats also update my Obsidian vault as a kind of explicit memory. Separately, Codex now has memory features in `Settings > Personalization > Memories`, including [Memories](https://developers.openai.com/codex/memories) and [Chronicle](https://developers.openai.com/codex/memories/chronicle).
+
+## Goals need an oracle
+
+The newest thing I am still learning how to use well is Goals.
+
+You should be ambitious with them. A weak goal is "implement the plan in this Markdown file." A strong goal has a real success criterion that the agent can keep pushing against.
+
+Last week I tried to migrate the Python [Rich](https://github.com/Textualize/rich) library into Rust. Because the original project already had a large unit test suite, I could set a goal like: migrate Rich into Rust, but it must pass all the unit tests from the original library.
+
+That test suite gave the run a real oracle: the Rust port was not done until it passed the same tests as the Python library.
+
+This is different from having a long conversation with an AI, accumulating a Markdown plan, and then eventually saying, "implement this." The execution is only going to be as good as the goal, the verification, and the validation you give it. Ambition matters, but ambition without verification is just a wish.
+
+## The side panel is where I stay in the loop
+
+The part of Codex I am most excited about is the side panel.
+
+It is easy to think of this as a place where previews happen. That undersells it. The side panel is where Codex stops being a chat app and starts becoming the place the work happens.
+
+For me it now does three different jobs: it lets me inspect artifacts, operate web surfaces, and review changes.
+
+The common thing is that I can look at and comment on the same object the agent is acting on.
+
+### Inspect artifacts
+
+Markdown, spreadsheets, CSVs, PDFs, and slides can all live there.
+
+Markdown is commentable. Spreadsheets render formulas and support cell edits, which I use to manage Codex open-source plans. CSVs become tables instead of raw text. PDFs render directly, which is especially useful with LaTeX. Slides can be created and reviewed without leaving the app.
+
+The important thing is not merely that Codex can generate artifacts. It is that I can inspect and annotate them without breaking the loop.
+
+### Operate web surfaces
+
+The in-app browser is even more interesting. The agent can see it, control it with JavaScript through `$browser`, and I can leave annotations directly on what I am looking at.
+
+There are a few web surfaces I now use this way all the time:
+
+- `index.html` for lightweight static artifacts
+- Storybook for reviewing UI components
+- Remotion Studio for programmatic animation
+- Slidev for presentations
+- Streamlit for data apps
+
+The smallest version is often the best. You can ask the model to make a single `index.html` file with JavaScript and CSS, open it in the side panel, and start interacting with it immediately. No server required. I have been experimenting with using Heartbeats to keep updating a static `index.html` over time so that whenever I return to a thread, there is already a fresh artifact waiting for me.
+
+[Thariq has a very good post](https://x.com/trq212/status/2052809885763747935) about preferring HTML over Markdown as an output format. I think that instinct is right. Once the output is a small application instead of just a document, the relationship changes.
+
+If I need something heavier, I can use a Vite app, but then I need to keep a server running. A plain `index.html` is much more durable.
+
+For animation work, I often have Storybook and Remotion Studio open side by side. I can leave comments like "make this bounce" or "this should be larger," and the agent can inspect the same browser state I am looking at, including the current frame in the animation.
+
+For presentations, I often use Slidev. Codex can inspect the slides, catch content that is cut off, switch between slides, and respond to annotations while I review.
+
+I also expect this to become more useful for tools like Streamlit and Jupyter over time. Different people already live inside different applications. Codex can increasingly meet them there.
+
+### Review changes
+
+The side panel also has a diff viewer. It can render the actual pull request diff and the GitHub comments attached to it. That matters because review is one of the few places where I still want the model and me to be looking at exactly the same object.
+
+The more Codex gets places to remember, revisit, inspect, and act, the less my work has to die between prompts. That is the change I care about. Not that an agent can write code for me, but that more of my work can keep moving after I leave.

--- a/docs/writing/posts/codex-maxxing.md
+++ b/docs/writing/posts/codex-maxxing.md
@@ -21,15 +21,15 @@ tags:
 
 I had already been using coding agents a lot before Codex. Mostly, though, I used them through interfaces built for coding work: making diffs, changing repos, and shipping code.
 
-Around November, I started pushing them into knowledge work too. I made presentations in Slidev, used agents more like note-takers, and kept looking for other artifacts a coding agent could help me produce.
+Around November, I started pushing them into knowledge work too. I made presentations in [Slidev](https://sli.dev/), used agents more like note-takers with voice inputs, and kept looking for other artifacts a coding agent could help me produce, make a index.html and then hit ctrl+p to make a pdf.
 
-The Codex app is the first thing I have used that makes that broader mode feel native for everyone. It is still excellent for coding, but the more interesting shift for me is that it gives work somewhere to live.
+The latest Codex app upgrades is the first thing I have used that makes that broader mode feel native for everyone. It is still excellent for coding, but the more interesting shift for me is that it gives all of my work somewhere to live.
 
-What changed my behavior was learning to give work five things: a durable thread, a place to remember, tools to act, a schedule that brings it back, and a surface I can review.
+What changed my behavior was learning to give work five things: a durable thread, a place to remember things, tools to act on my whole computer, a schedule that brings it back, and a surface I can review any kind of work, website, markdown, pdf, spreadsheets, and slides.
 
 <!-- more -->
 
-## Compaction made threads durable
+## Durable threads 
 
 The first thing that changed my behavior was compaction.
 
@@ -49,7 +49,7 @@ These are not short chats. They are megathreads that I have been compacting for 
 
 There is a tradeoff here. Long-running threads are not free. If you revisit them later, the conversation is probably no longer in cache, so you can incur more cost than you would in a fresh short thread. But for workstreams I care about, continuity is often more valuable than purity.
 
-## Voice input gives the agent the unedited version
+## Voice input
 
 One underrated part of this workflow is getting more of my actual thinking into Codex.
 
@@ -57,7 +57,7 @@ The real benefit of voice input is not speed. It is that I give the agent the un
 
 The same thing applies to transcripts. If I want to write a post, I can call someone, record the conversation, or talk to them in person with Granola on my phone, then use the transcript as the starting material. A lot of plans get better when the model has access to the messy version of what I think, not just the polished one.
 
-## Steering lets me keep adding intent
+## Steering
 
 Voice becomes more useful when combined with steering.
 
@@ -74,7 +74,7 @@ I do not need to wait for each step to finish before deciding the next one. I ca
 
 Later, Heartbeats can monitor the PR or the Slack thread after I leave. The unit of work stops being "one prompt, one answer." It becomes a small operating loop.
 
-## Give the agent somewhere to remember
+## Memory
 
 Once threads started lasting longer, they needed shared memory outside any one repo.
 
@@ -102,7 +102,7 @@ When the agent updates the vault, I can read the diff and see what it thought wa
 
 At that point, pinned threads start to feel less like chats and more like different workers with access to the same shared memory.
 
-## Give those threads reach
+## Computer and Browser Use
 
 Once a thread has memory, the next question is what it can act on.
 
@@ -116,11 +116,21 @@ If I am iterating on a local app, I want `$browser`. If I need to work inside a 
 
 On my work machine, Twitter is logged into Safari. If I have `@computer` read Twitter there, I lose Safari while it works. `@chrome` is better when I want the agent to use several authenticated tabs in parallel without taking over the whole app I am using.
 
-Connectors extend that reach into Slack, Gmail, and Calendar, where much of my work already happens.
+Connectors extend that reach into the rest of my actual work. The ones I use most are `$slack`, `$gmail`, and `$calendar`, because Slack threads, inboxes, and calendars are where a lot of work shows up before it ever becomes code.
 
-Skills make repeated workflows reusable. Skill Creator and Skill Installer are a good place to start. Skill Installer lets you add OpenAI-recommended skills directly from the composer. I used it to install the Hatch Pet skill, but the useful pattern is general: once you do something useful once, you can often package it so Codex can do it again without reteaching the workflow.
+Skills make repeated workflows reusable. Skill Creator and Skill Installer are a good place to start. Skill Installer lets you add OpenAI-recommended skills directly from the composer. After [Codex pets](https://developers.openai.com/codex/app/settings#codex-pets) launched, I used it to install the Hatch Pet skill, but the useful pattern is general: once you do something useful once, you can often package it so Codex can do it again without reteaching the workflow.
 
-## Heartbeats make threads come back on their own
+## Remote control
+
+Remote Control is what makes these longer loops feel portable.
+
+The public framing is simple: Codex can keep working from the machine where your files, permissions, and local setup already live, while you check in from mobile, review what it found, answer a question, approve the next step, or change direction without being back at your desk. [OpenAI describes it as a way to work with Codex from anywhere](https://openai.com/index/work-with-codex-from-anywhere/).
+
+What I liked in the internal Slack discussion was the more practical framing: this is especially useful when Codex is already doing something long-running and you want to preserve momentum instead of waiting until you are back at your laptop. You can start a task, walk away, then steer it from your phone when it reaches a decision point.
+
+That matters for the same reason pinned threads, voice, and Heartbeats matter. The work no longer has to pause just because I changed locations. A thread can keep going, and I can keep just enough attention on it to unblock the next move.
+
+## Heartbeats
 
 Pinned threads are useful, but they still wait for you to say something. Heartbeats are what make them recur.
 
@@ -160,7 +170,7 @@ By the time I got out of the shower, the refund was done.
 
 Many of my Heartbeats also update my Obsidian vault as a kind of explicit memory. Separately, Codex now has memory features in `Settings > Personalization > Memories`, including [Memories](https://developers.openai.com/codex/memories) and [Chronicle](https://developers.openai.com/codex/memories/chronicle).
 
-## Goals need an oracle
+## Goals
 
 The newest thing I am still learning how to use well is Goals.
 
@@ -172,9 +182,13 @@ That test suite gave the run a real oracle: the Rust port was not done until it 
 
 This is different from having a long conversation with an AI, accumulating a Markdown plan, and then eventually saying, "implement this." The execution is only going to be as good as the goal, the verification, and the validation you give it. Ambition matters, but ambition without verification is just a wish.
 
-## The side panel is where I stay in the loop
+I ended up pulling this idea into a shorter companion piece: [Using Codex: Getting the most out of Goal mode](./codex-goals.md). The core argument is simple: Goal mode is not mainly about letting Codex work longer. It is about defining work clearly enough that an agent can keep improving it without you supervising every step.
+
+## The side panel
 
 The part of Codex I am most excited about is the side panel.
+
+![A shared side panel for artifacts, browser surfaces, and review](./img/codex-maxxing-side-panel.png)
 
 It is easy to think of this as a place where previews happen. That undersells it. The side panel is where Codex stops being a chat app and starts becoming the place the work happens.
 
@@ -199,7 +213,7 @@ There are a few web surfaces I now use this way all the time:
 - `index.html` for lightweight static artifacts
 - Storybook for reviewing UI components
 - Remotion Studio for programmatic animation
-- Slidev for presentations
+- [Slidev](https://sli.dev/guide/) for presentations
 - Streamlit for data apps
 
 The smallest version is often the best. You can ask the model to make a single `index.html` file with JavaScript and CSS, open it in the side panel, and start interacting with it immediately. No server required. I have been experimenting with using Heartbeats to keep updating a static `index.html` over time so that whenever I return to a thread, there is already a fresh artifact waiting for me.
@@ -214,8 +228,5 @@ For presentations, I often use Slidev. Codex can inspect the slides, catch conte
 
 I also expect this to become more useful for tools like Streamlit and Jupyter over time. Different people already live inside different applications. Codex can increasingly meet them there.
 
-### Review changes
-
-The side panel also has a diff viewer. It can render the actual pull request diff and the GitHub comments attached to it. That matters because review is one of the few places where I still want the model and me to be looking at exactly the same object.
 
 The more Codex gets places to remember, revisit, inspect, and act, the less my work has to die between prompts. That is the change I care about. Not that an agent can write code for me, but that more of my work can keep moving after I leave.


### PR DESCRIPTION
## Summary

Adds a new draft post, `Codex-maxxing`, about using Codex for long-running work across threads, vault memory, Heartbeats, goals, and the side panel.

## Why

The blog did not yet have a post capturing the shift from using coding agents only for code changes to using Codex as a broader work surface for knowledge work, recurring tasks, artifacts, and review loops.

## What changed

- added `docs/writing/posts/codex-maxxing.md`
- kept the post focused on concrete workflows rather than a generic feature tour
- included examples around pinned threads, voice input, vault-backed memory, plugins/connectors, Heartbeats, Goals, and the side panel

## Validation

- ran `uv run ./build_mkdocs_with_cairo.sh`
- build completed successfully

## Follow-up

This draft still uses direct outbound links because `DUB_API_KEY` was not available locally, so the repo-required `scripts/shortlinks.py` pass could not be completed before opening the PR.
