### PR TITLE
fix: include historical blog page views

### DIFF
--- a/scripts/page_views.py
+++ b/scripts/page_views.py
@@ -31,13 +31,19 @@ def normalize_path(path: str) -> str:
 
 def aggregate_page_views(
     rows: Iterable[PageViewRow],
-    allowed_hosts: Iterable[str] = ("jxnl.co", "www.jxnl.co"),
+    allowed_hosts: Iterable[str] = (
+        "jxnl.co",
+        "www.jxnl.co",
+        "jxnl.github.io",
+    ),
 ) -> Mapping[str, int]:
-    """Combine GA page-view rows into canonical path totals."""
+    """Combine current and historical GA page-view rows into canonical totals."""
     hosts = set(allowed_hosts)
     totals: defaultdict[str, int] = defaultdict(int)
     for host, path, views in rows:
         normalized = normalize_path(path)
+        if host == "jxnl.github.io" and normalized.startswith("/blog/"):
+            normalized = normalized[len("/blog") :]
         if host in hosts and POST_PATH.fullmatch(normalized):
             totals[normalized] += int(views)
     return dict(sorted(totals.items()))
@@ -81,7 +87,7 @@ def fetch_page_views(
             property=f"properties/{property_id}",
             dimensions=[Dimension(name="hostName"), Dimension(name="pagePath")],
             metrics=[Metric(name="screenPageViews")],
-            date_ranges=[DateRange(start_date="2020-01-01", end_date="yesterday")],
+            date_ranges=[DateRange(start_date="2015-08-14", end_date="yesterday")],
             limit=250_000,
         )
     )

--- a/tests/test_page_views.py
+++ b/tests/test_page_views.py
@@ -12,11 +12,12 @@ class AggregatePageViewsTests(unittest.TestCase):
             ("jxnl.co", "/writing/2026/06/28/example/", 10),
             ("www.jxnl.co", "/writing/2026/06/28/example/index.html", 4),
             ("jxnl.co", "/writing/2026/06/28/example?ref=twitter", 2),
+            ("jxnl.github.io", "/blog/writing/2026/06/28/example/", 8),
         ]
 
         self.assertEqual(
             aggregate_page_views(rows),
-            {"/writing/2026/06/28/example/": 16},
+            {"/writing/2026/06/28/example/": 24},
         )
 
     def test_excludes_other_hosts_and_non_post_paths(self):


### PR DESCRIPTION
## Summary
- query GA from its earliest supported date, 2015-08-14
- include historical jxnl.github.io traffic
- map old /blog/writing/... paths to current /writing/... URLs

## Verification
- 3 page-view tests pass
- GA returns 315 post counts
- Losing My Hands resolves to 13,248 all-history views