### PR TITLE
Add popular posts page

### DIFF
--- a/docs/javascripts/page-views.js
+++ b/docs/javascripts/page-views.js
@@ -1,5 +1,6 @@
 (function () {
   var snapshot;
+  var feed;
 
   function loadSnapshot() {
     if (!snapshot) {
@@ -18,6 +19,23 @@
     return snapshot;
   }
 
+  function loadFeed() {
+    if (!feed) {
+      feed = fetch("/feed_json_created.json", { credentials: "same-origin" })
+        .then(function (response) {
+          if (!response.ok) throw new Error("post feed unavailable");
+          return response.json();
+        })
+        .then(function (data) {
+          return data.items || [];
+        })
+        .catch(function () {
+          return [];
+        });
+    }
+    return feed;
+  }
+
   function normalizePath(value) {
     var path = new URL(value, window.location.origin).pathname;
     if (path.endsWith("/index.html")) path = path.slice(0, -"index.html".length);
@@ -32,6 +50,32 @@
         maximumFractionDigits: 1,
       }).format(count) + " views"
     );
+  }
+
+  function formatDate(value) {
+    if (!value) return "";
+
+    return new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(value));
+  }
+
+  function textFromHtml(value) {
+    var element = document.createElement("div");
+    element.innerHTML = value || "";
+    return element.textContent.trim();
+  }
+
+  function getPostLink(post) {
+    return post.querySelector(".md-post__content h2 a[href]");
+  }
+
+  function getPostViewCount(post, views) {
+    var link = getPostLink(post);
+    if (!link) return 0;
+    return views[normalizePath(link.href)] || 0;
   }
 
   function renderPostPage(views) {
@@ -70,13 +114,14 @@
 
   function renderPostListings(views) {
     document.querySelectorAll("article.md-post--excerpt").forEach(function (post) {
+      post.setAttribute("data-page-views", String(getPostViewCount(post, views)));
+
       if (post.querySelector(".md-meta__item--views")) return;
 
-      var link = post.querySelector(".md-post__content h2 a[href]");
       var metadata = post.querySelector(".md-meta__list");
-      if (!link || !metadata) return;
+      if (!metadata) return;
 
-      var count = views[normalizePath(link.href)];
+      var count = Number(post.getAttribute("data-page-views") || 0);
       if (!count) return;
 
       var element = document.createElement("li");
@@ -86,10 +131,93 @@
     });
   }
 
+  function renderPopularItem(post) {
+    var item = document.createElement("li");
+    item.className = "popular-post";
+
+    var header = document.createElement("div");
+    header.className = "popular-post__header";
+
+    var title = document.createElement("a");
+    title.className = "popular-post__title";
+    title.href = post.path;
+    title.textContent = post.title;
+
+    var views = document.createElement("span");
+    views.className = "popular-post__views";
+    views.textContent = formatViews(post.views);
+
+    header.appendChild(title);
+    header.appendChild(views);
+    item.appendChild(header);
+
+    var meta = document.createElement("div");
+    meta.className = "popular-post__meta";
+    meta.textContent = formatDate(post.date);
+    item.appendChild(meta);
+
+    if (post.description) {
+      var description = document.createElement("p");
+      description.className = "popular-post__description";
+      description.textContent = post.description;
+      item.appendChild(description);
+    }
+
+    return item;
+  }
+
+  function renderPopularPage(views) {
+    var container = document.querySelector("[data-popular-posts]");
+    if (!container) return;
+
+    loadFeed().then(function (items) {
+      if (!container.isConnected) return;
+
+      var posts = items
+        .map(function (item) {
+          var path = normalizePath(item.url || item.id);
+          return {
+            date: item.date_published || item.date_modified,
+            description: textFromHtml(item.content_html),
+            path: path,
+            title: item.title,
+            views: views[path] || 0,
+          };
+        })
+        .filter(function (item) {
+          return item.title && item.path && item.views;
+        })
+        .sort(function (first, second) {
+          if (first.views !== second.views) return second.views - first.views;
+          return new Date(second.date) - new Date(first.date);
+        });
+
+      container.textContent = "";
+
+      if (!posts.length) {
+        var empty = document.createElement("p");
+        empty.className = "popular-posts__status";
+        empty.textContent = "Popular posts will appear here once page-view data is available.";
+        container.appendChild(empty);
+        return;
+      }
+
+      var list = document.createElement("ol");
+      list.className = "popular-posts__list";
+
+      posts.forEach(function (post) {
+        list.appendChild(renderPopularItem(post));
+      });
+
+      container.appendChild(list);
+    });
+  }
+
   function renderPageViews() {
     loadSnapshot().then(function (views) {
       renderPostPage(views);
       renderPostListings(views);
+      renderPopularPage(views);
     });
   }
 

--- a/docs/javascripts/page-views.js
+++ b/docs/javascripts/page-views.js
@@ -59,6 +59,7 @@
       year: "numeric",
       month: "short",
       day: "numeric",
+      timeZone: "UTC",
     }).format(new Date(value));
   }
 

--- a/docs/javascripts/page-views.js
+++ b/docs/javascripts/page-views.js
@@ -1,6 +1,6 @@
 (function () {
   var snapshot;
-  var feed;
+  var searchIndex;
 
   function loadSnapshot() {
     if (!snapshot) {
@@ -19,21 +19,21 @@
     return snapshot;
   }
 
-  function loadFeed() {
-    if (!feed) {
-      feed = fetch("/feed_json_created.json", { credentials: "same-origin" })
+  function loadSearchIndex() {
+    if (!searchIndex) {
+      searchIndex = fetch("/search/search_index.json", { credentials: "same-origin" })
         .then(function (response) {
-          if (!response.ok) throw new Error("post feed unavailable");
+          if (!response.ok) throw new Error("search index unavailable");
           return response.json();
         })
         .then(function (data) {
-          return data.items || [];
+          return data.docs || [];
         })
         .catch(function () {
           return [];
         });
     }
-    return feed;
+    return searchIndex;
   }
 
   function normalizePath(value) {
@@ -53,7 +53,7 @@
   }
 
   function formatDate(value) {
-    if (!value) return "";
+    if (!value || Number.isNaN(new Date(value).getTime())) return "";
 
     return new Intl.DateTimeFormat("en", {
       year: "numeric",
@@ -65,7 +65,23 @@
   function textFromHtml(value) {
     var element = document.createElement("div");
     element.innerHTML = value || "";
-    return element.textContent.trim();
+    return element.textContent.replace(/\s+/g, " ").trim();
+  }
+
+  function summarizeText(value) {
+    var text = textFromHtml(value);
+    if (text.length <= 240) return text;
+    return text.slice(0, 237).trim() + "...";
+  }
+
+  function getDateFromPath(path) {
+    var match = path.match(/^\/writing\/(\d{4})\/(\d{2})\/(\d{2})\/[^/]+\/$/);
+    if (!match) return "";
+    return match.slice(1).join("-");
+  }
+
+  function isPostPath(path) {
+    return /^\/writing\/\d{4}\/\d{2}\/\d{2}\/[^/]+\/$/.test(path);
   }
 
   function getPostLink(post) {
@@ -170,22 +186,32 @@
     var container = document.querySelector("[data-popular-posts]");
     if (!container) return;
 
-    loadFeed().then(function (items) {
+    loadSearchIndex().then(function (items) {
       if (!container.isConnected) return;
 
-      var posts = items
-        .map(function (item) {
-          var path = normalizePath(item.url || item.id);
-          return {
-            date: item.date_published || item.date_modified,
-            description: textFromHtml(item.content_html),
-            path: path,
-            title: item.title,
-            views: views[path] || 0,
-          };
+      var postsByPath = {};
+      items.forEach(function (item) {
+        var location = item.location || "";
+        if (location.indexOf("#") !== -1) return;
+
+        var path = normalizePath(location);
+        if (!item.title || !isPostPath(path)) return;
+
+        postsByPath[path] = {
+          date: getDateFromPath(path),
+          description: summarizeText(item.text),
+          path: path,
+          title: item.title,
+          views: views[path] || 0,
+        };
+      });
+
+      var posts = Object.keys(postsByPath)
+        .map(function (path) {
+          return postsByPath[path];
         })
         .filter(function (item) {
-          return item.title && item.path && item.views;
+          return item.views;
         })
         .sort(function (first, second) {
           if (first.views !== second.views) return second.views - first.views;

--- a/docs/popular.md
+++ b/docs/popular.md
@@ -1,0 +1,11 @@
+---
+description: Most-read writing on Jason Liu's blog, ranked by all-time page views.
+---
+
+# Popular
+
+Most-read posts, ranked by all-time page views.
+
+<div class="popular-posts" data-popular-posts>
+  <p class="popular-posts__status">Loading popular posts...</p>
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -107,3 +107,63 @@
 .md-nav__item--views {
   white-space: nowrap;
 }
+
+.popular-posts {
+  margin-top: 1.5rem;
+}
+
+.popular-posts__status {
+  color: var(--md-default-fg-color--light);
+}
+
+.popular-posts__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.popular-post {
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  padding: 1rem 0;
+}
+
+.popular-post:last-child {
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.popular-post__header {
+  align-items: baseline;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.popular-post__title {
+  font-weight: 700;
+}
+
+.popular-post__views {
+  color: var(--md-accent-fg-color);
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.popular-post__meta {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+.popular-post__description {
+  color: var(--md-default-fg-color--light);
+  margin: 0.5rem 0 0;
+}
+
+@media screen and (max-width: 44.9844em) {
+  .popular-post__header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}

--- a/docs/writing/index.md
+++ b/docs/writing/index.md
@@ -12,7 +12,7 @@ tags:
 
 # Writing
 
-[Subscribe to my newsletter](https://dub.link/S4G5XGs) · [Follow me on X](https://x.com/jxnlco)
+[Popular posts](../popular.md){ .md-button } [Subscribe to my newsletter](https://dub.link/S4G5XGs){ .md-button .md-button--primary } [Follow me on X](https://x.com/jxnlco){ .md-button }
 
 ## Personal
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,6 @@ nav:
     - Books: 'books.md'
     - Resume: "resume.md"
   - Writing: "writing/index.md"
-  - Popular: "popular.md"
 plugins:
   - social
   - rss:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - Books: 'books.md'
     - Resume: "resume.md"
   - Writing: "writing/index.md"
+  - Popular: "popular.md"
 plugins:
   - social
   - rss:

--- a/scripts/page_views.py
+++ b/scripts/page_views.py
@@ -7,13 +7,14 @@ import logging
 import os
 from pathlib import Path
 import re
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import Callable, Iterable, Iterator, Mapping, Optional, Tuple
 from urllib.parse import urlsplit
 
 
 PageViewRow = Tuple[str, str, int]
 POST_PATH = re.compile(r"^/writing/\d{4}/\d{2}/\d{2}/[^/]+/$")
 ANALYTICS_READ_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
+REPORT_ROW_LIMIT = 250_000
 LOGGER = logging.getLogger("mkdocs.hooks.page_views")
 
 
@@ -63,6 +64,24 @@ def write_snapshot(
     destination.write_text(f"{json.dumps(payload, indent=2)}\n")
 
 
+def iter_report_rows(
+    client,
+    make_request: Callable[[int, int], object],
+    limit: int = REPORT_ROW_LIMIT,
+) -> Iterator[object]:
+    """Yield every row from a potentially paginated GA Data API report."""
+    offset = 0
+    while True:
+        response = client.run_report(make_request(offset, limit))
+        rows = tuple(response.rows)
+        yield from rows
+
+        offset += len(rows)
+        row_count = getattr(response, "row_count", 0)
+        if not rows or len(rows) < limit or (row_count and offset >= row_count):
+            break
+
+
 def fetch_page_views(
     property_id: str,
     service_account_json: str,
@@ -82,22 +101,24 @@ def fetch_page_views(
         scopes=[ANALYTICS_READ_SCOPE],
     )
     client = BetaAnalyticsDataClient(credentials=credentials)
-    response = client.run_report(
-        RunReportRequest(
+
+    def make_request(offset: int, limit: int) -> RunReportRequest:
+        return RunReportRequest(
             property=f"properties/{property_id}",
             dimensions=[Dimension(name="hostName"), Dimension(name="pagePath")],
             metrics=[Metric(name="screenPageViews")],
             date_ranges=[DateRange(start_date="2015-08-14", end_date="yesterday")],
-            limit=250_000,
+            limit=limit,
+            offset=offset,
         )
-    )
+
     rows = (
         (
             row.dimension_values[0].value,
             row.dimension_values[1].value,
             int(row.metric_values[0].value),
         )
-        for row in response.rows
+        for row in iter_report_rows(client, make_request)
     )
     return aggregate_page_views(rows)
 

--- a/scripts/page_views.py
+++ b/scripts/page_views.py
@@ -15,6 +15,12 @@ PageViewRow = Tuple[str, str, int]
 POST_PATH = re.compile(r"^/writing/\d{4}/\d{2}/\d{2}/[^/]+/$")
 ANALYTICS_READ_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
 REPORT_ROW_LIMIT = 250_000
+PATH_ALIASES = {
+    "/writing/2024/01/01/whoami/": "/writing/2024/10/31/whoami/",
+    "/writing/2025/06/15/my-self-reflection-on-success-and-growth/": (
+        "/writing/2024/06/15/my-self-reflection-on-success-and-growth/"
+    ),
+}
 LOGGER = logging.getLogger("mkdocs.hooks.page_views")
 
 
@@ -45,6 +51,7 @@ def aggregate_page_views(
         normalized = normalize_path(path)
         if host == "jxnl.github.io" and normalized.startswith("/blog/"):
             normalized = normalized[len("/blog") :]
+        normalized = PATH_ALIASES.get(normalized, normalized)
         if host in hosts and POST_PATH.fullmatch(normalized):
             totals[normalized] += int(views)
     return dict(sorted(totals.items()))

--- a/tests/test_page_views.py
+++ b/tests/test_page_views.py
@@ -33,6 +33,30 @@ class AggregatePageViewsTests(unittest.TestCase):
             {"/writing/2026/06/28/example/": 5},
         )
 
+    def test_combines_confirmed_legacy_post_paths(self):
+        rows = [
+            ("jxnl.co", "/writing/2024/01/01/whoami/", 3674),
+            ("jxnl.co", "/writing/2024/10/31/whoami/", 383),
+            (
+                "jxnl.co",
+                "/writing/2025/06/15/my-self-reflection-on-success-and-growth/",
+                636,
+            ),
+            (
+                "jxnl.co",
+                "/writing/2024/06/15/my-self-reflection-on-success-and-growth/",
+                180,
+            ),
+        ]
+
+        self.assertEqual(
+            aggregate_page_views(rows),
+            {
+                "/writing/2024/06/15/my-self-reflection-on-success-and-growth/": 816,
+                "/writing/2024/10/31/whoami/": 4057,
+            },
+        )
+
 
 class IterReportRowsTests(unittest.TestCase):
     def test_reads_all_pages_until_report_row_count_is_reached(self):

--- a/tests/test_page_views.py
+++ b/tests/test_page_views.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from scripts.page_views import aggregate_page_views, write_snapshot
+from scripts.page_views import aggregate_page_views, iter_report_rows, write_snapshot
 
 
 class AggregatePageViewsTests(unittest.TestCase):
@@ -31,6 +31,42 @@ class AggregatePageViewsTests(unittest.TestCase):
         self.assertEqual(
             aggregate_page_views(rows),
             {"/writing/2026/06/28/example/": 5},
+        )
+
+
+class IterReportRowsTests(unittest.TestCase):
+    def test_reads_all_pages_until_report_row_count_is_reached(self):
+        class Response:
+            def __init__(self, rows, row_count):
+                self.rows = rows
+                self.row_count = row_count
+
+        class Client:
+            def __init__(self):
+                self.requests = []
+                self.responses = [
+                    Response(["first", "second"], 4),
+                    Response(["third", "fourth"], 4),
+                ]
+
+            def run_report(self, request):
+                self.requests.append(request)
+                return self.responses.pop(0)
+
+        client = Client()
+
+        rows = list(
+            iter_report_rows(
+                client,
+                lambda offset, limit: {"offset": offset, "limit": limit},
+                limit=2,
+            )
+        )
+
+        self.assertEqual(rows, ["first", "second", "third", "fourth"])
+        self.assertEqual(
+            client.requests,
+            [{"offset": 0, "limit": 2}, {"offset": 2, "limit": 2}],
         )
 
 


### PR DESCRIPTION
## Summary

Adds a dedicated `/popular/` page that ranks posts by all-time page views using the existing `/assets/page-views.json` snapshot and the generated MkDocs search index for complete post metadata.

Links the page from the Writing index with a `Popular posts` button, without adding `Popular` as a top-level navigation tab.

Hardens the GA snapshot build step to paginate through report rows until the full GA row count is loaded. It also folds two confirmed legacy URLs into their current post URLs, recovering 4,310 tracked views that were otherwise omitted.

Fixes date rendering so post dates do not shift backward in US time zones.

## Validation

- `node --check docs/javascripts/page-views.js`
- `PYTHONPATH=. uv run python -m unittest discover -s tests -v`
- `uv run mkdocs build`
- `git diff --check`
- Cloudflare preview verification

Note: local builds write an empty page-view snapshot when GA credentials are not configured, so `/popular/` populates from the production-configured Cloudflare preview.