### PR TITLE
fix(user-manual): switch examples around to resolve logical error

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -34,7 +34,7 @@ How to work with me effectively. I'm learning to delegate more so I can focus on
 
 **I'm often mobile.** Messages should be structured for quick skimming. Put key info at the top.
 
-**Ask specific questions.** Frame questions so they can be answered with yes/no or numbers. "How can I help?" beats "Do you think I should work on X?"
+**Ask specific questions.** Frame questions so they can be answered with yes/no or numbers. "Do you think I should work on X?" beats "How can I help?"
 
 **Prep me for meetings.** Send materials before to reset my focus. Follow up with summary and action items.
 


### PR DESCRIPTION
Fixes the following:
- Switching around the quoted examples in the statement '"How can I help?" beats "Do you think I should work on X?"' so that it makes sense in [context](https://jxnl.co/user_manual/#pet-peeves:~:text=Ask%20specific%20questions.%20Frame%20questions%20so%20they%20can%20be%20answered%20with%20yes/no%20or%20numbers.%20%22How%20can%20I%20help%3F%22%20beats%20%22Do%20you%20think%20I%20should%20work%20on%20X%3F%22).